### PR TITLE
Add plate count filter and remove combo ordering

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2,7 +2,6 @@ import { loadData, DATA, INDEX } from "./data.js";
 import { nearestKeys, rangeKeys, sortResultsArray } from "./search.js";
 import { render } from "./render.js";
 import { loadState, bindStateAutosave } from "./state.js";
-import { fmt } from "./utils.js";
 
 const $ = (id) => document.getElementById(id);
 const modeSel = $("mode");
@@ -16,8 +15,13 @@ const tolInp = $("tol");
 const capPerWeight = $("capPerWeight");
 const emptyPolicy = $("emptyPolicy");
 const sortResults = $("sortResults");
-const sortCombos = $("sortCombos");
 const results = $("results");
+const minPlates = $("minPlates");
+const maxPlates = $("maxPlates");
+const minPlatesDec = $("minPlatesDec");
+const minPlatesInc = $("minPlatesInc");
+const maxPlatesDec = $("maxPlatesDec");
+const maxPlatesInc = $("maxPlatesInc");
 
 modeSel.addEventListener("change", ()=>{
   const isRange = modeSel.value === "range";
@@ -25,12 +29,11 @@ modeSel.addEventListener("change", ()=>{
   rangeBox.style.display = isRange ? "" : "none";
 });
 
-$("go").addEventListener("click", ()=>{
+function runSearch(){
   if (!DATA){ alert("Cargando datos…"); return; }
   const cap = parseInt(capPerWeight.value || "6", 10);
   const emptyPol = emptyPolicy.value;
   const sortResMode = sortResults.value;
-  const sortCombosMode = sortCombos.value;
 
   let keys = [];
   let target = null;
@@ -50,16 +53,64 @@ $("go").addEventListener("click", ()=>{
   for (const k of keys){
     const entry = INDEX.byKey.get(k.toFixed(2));
     if (!entry) continue;
+    const combos = (entry.combos || []).slice(0, cap);
     itemsRaw.push({
       kg: entry.kg,
-      combos: (entry.combos || []).slice(0, cap)
+      combos,
+      minPlates: combos.length ? Math.min(...combos.map(c => c.length)) : Infinity
     });
   }
 
+  let minGlobal = Infinity, maxGlobal = -Infinity;
+  for (const it of itemsRaw){
+    if (it.minPlates < minGlobal) minGlobal = it.minPlates;
+    if (it.minPlates > maxGlobal) maxGlobal = it.minPlates;
+  }
+  if (!isFinite(minGlobal) || !isFinite(maxGlobal)){
+    minGlobal = 0; maxGlobal = 0;
+  }
+  minPlates.min = minGlobal; minPlates.max = maxGlobal;
+  maxPlates.min = minGlobal; maxPlates.max = maxGlobal;
+  let minVal = parseInt(minPlates.value || minGlobal, 10);
+  let maxVal = parseInt(maxPlates.value || maxGlobal, 10);
+  if (minVal < minGlobal) minVal = minGlobal;
+  if (maxVal > maxGlobal) maxVal = maxGlobal;
+  if (minVal > maxVal) maxVal = minVal;
+  minPlates.value = String(minVal);
+  maxPlates.value = String(maxVal);
+
+  const itemsFiltered = itemsRaw.filter(it => it.minPlates >= minVal && it.minPlates <= maxVal);
+
   // Ordena resultados (tarjetas)
-  const items = sortResultsArray(itemsRaw, sortResMode, target);
-  render(results, items, { target, comboSort: sortCombosMode, emptyPolicy: emptyPol });
-});
+  const items = sortResultsArray(itemsFiltered, sortResMode, target);
+  render(results, items, { target, emptyPolicy: emptyPol });
+}
+
+$("go").addEventListener("click", runSearch);
+
+function adjustAndRun(inp, delta){
+  let val = parseInt(inp.value || "0", 10) + delta;
+  const mn = parseInt(inp.min || "0", 10);
+  const mx = parseInt(inp.max || "0", 10);
+  if (val < mn) val = mn;
+  if (val > mx) val = mx;
+  inp.value = String(val);
+  if (inp === minPlates && val > parseInt(maxPlates.value || "0", 10)) {
+    maxPlates.value = String(val);
+    maxPlates.dispatchEvent(new Event("change"));
+  }
+  if (inp === maxPlates && val < parseInt(minPlates.value || "0", 10)) {
+    minPlates.value = String(val);
+    minPlates.dispatchEvent(new Event("change"));
+  }
+  inp.dispatchEvent(new Event("change"));
+  runSearch();
+}
+
+minPlatesDec.addEventListener("click", ()=>adjustAndRun(minPlates,-1));
+minPlatesInc.addEventListener("click", ()=>adjustAndRun(minPlates,1));
+maxPlatesDec.addEventListener("click", ()=>adjustAndRun(maxPlates,-1));
+maxPlatesInc.addEventListener("click", ()=>adjustAndRun(maxPlates,1));
 
 // Inicialización
 (async function init(){

--- a/assets/js/render.js
+++ b/assets/js/render.js
@@ -1,12 +1,10 @@
 import { fontContrast, fmt } from "./utils.js";
 import { DATA } from "./data.js";
-import { sortCombosInCard } from "./search.js";
 
 // Renderiza tarjetas en #results
 export function render(resultsRoot, items, opts = {}){
   const plates = DATA.meta.plates;
   const target = (opts && typeof opts.target === "number") ? opts.target : null;
-  const comboSort = (opts && opts.comboSort) ? opts.comboSort : "default";
   const emptyPolicy = (opts && opts.emptyPolicy) || "hide";
 
   resultsRoot.innerHTML = "";
@@ -44,9 +42,7 @@ export function render(resultsRoot, items, opts = {}){
       continue;
     }
 
-    const combosSorted = sortCombosInCard(row.combos, comboSort);
-
-    for (const combo of combosSorted){
+    for (const combo of row.combos){
       const line = document.createElement("div");
       line.className = "line";
       for (const idx of combo){

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -16,7 +16,7 @@ export function nearestKeys(keys, target, tol){
     return arr;
   }
   
-  export function sortResultsArray(items, mode, target){
+export function sortResultsArray(items, mode, target){
     const arr = items.slice();
     if (mode === "asc") arr.sort((a,b)=> a.kg - b.kg);
     else if (mode === "desc") arr.sort((a,b)=> b.kg - a.kg);
@@ -24,15 +24,15 @@ export function nearestKeys(keys, target, tol){
       arr.sort((a,b)=> Math.abs(a.kg - target) - Math.abs(b.kg - target));
     else if (mode === "farthest" && typeof target === "number")
       arr.sort((a,b)=> Math.abs(b.kg - target) - Math.abs(a.kg - target));
+    else if (mode === "plates")
+      arr.sort((a,b)=> {
+        const diff = a.minPlates - b.minPlates;
+        if (diff !== 0) return diff;
+        if (typeof target === "number")
+          return Math.abs(a.kg - target) - Math.abs(b.kg - target);
+        return a.kg - b.kg;
+      });
     else arr.sort((a,b)=> a.kg - b.kg);
     return arr;
-  }
-  
-  export function sortCombosInCard(combos, mode){
-    const out = combos.slice();
-    if (mode === "fewest") out.sort((a,b)=> a.length - b.length);
-    else if (mode === "most") out.sort((a,b)=> b.length - a.length);
-    // 'default': respeta el orden del JSON (ya rankeado en el generador)
-    return out;
   }
   

--- a/assets/js/state.js
+++ b/assets/js/state.js
@@ -1,7 +1,7 @@
 // Persistencia simple de opciones en localStorage
 const STATE_KEYS = [
     "mode","exactKg","minKg","maxKg","stepKg",
-    "tol","capPerWeight","emptyPolicy","sortResults","sortCombos"
+    "tol","capPerWeight","emptyPolicy","sortResults","minPlates","maxPlates"
   ];
   
   export function loadState(){

--- a/index.html
+++ b/index.html
@@ -68,16 +68,27 @@
           <option value="desc">kg ↓</option>
           <option value="closest">± a meta</option>
           <option value="farthest">lejos de meta</option>
+          <option value="plates">menos discos</option>
         </select>
       </div>
 
-      <div>
-        <label for="sortCombos">Orden combos</label>
-        <select id="sortCombos">
-          <option value="default">predeterminado</option>
-          <option value="fewest">menos discos</option>
-          <option value="most">más discos</option>
-        </select>
+      <div class="row">
+        <div>
+          <label for="minPlates">Discos mín</label>
+          <div class="counter">
+            <button id="minPlatesDec" type="button">-</button>
+            <input id="minPlates" type="number" value="0" />
+            <button id="minPlatesInc" type="button">+</button>
+          </div>
+        </div>
+        <div>
+          <label for="maxPlates">Discos máx</label>
+          <div class="counter">
+            <button id="maxPlatesDec" type="button">-</button>
+            <input id="maxPlates" type="number" value="0" />
+            <button id="maxPlatesInc" type="button">+</button>
+          </div>
+        </div>
       </div>
 
       <div>


### PR DESCRIPTION
## Summary
- remove combo ordering option from UI and code
- add adjustable plate count filter with auto-updating min and max values
- persist plate count filter in local storage state

## Testing
- `node --check assets/js/app.js`
- `node --check assets/js/search.js`
- `node --check assets/js/render.js`
- `node --check assets/js/state.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4de3b64208327b122e1ff70415ebc